### PR TITLE
refactor(structure): Move exercises around different katas

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,10 +43,10 @@ dojo $ npm test
     return new TSError(diagnosticText, diagnosticCodes)
            ^
 TSError: ⨯ Unable to compile TypeScript:
-kata1.spec.ts:1:42 - error TS2307: Cannot find module './kata1'.
+kata1.spec.ts:1:42 - error TS2307: Cannot find module './api'.
 
-1 import { BaseParser, ParsingError } from "./kata1";
-                                           ~~~~~~~~~
+1 import { BaseParser, ParsingError } from "./api";
+                                           ~~~~~~~
 
     at createTSError (/tmp/dojo/node_modules/ts-node/src/index.ts:293:12)
     at reportTSError (/tmp/dojo/node_modules/ts-node/src/index.ts:297:19)
@@ -59,7 +59,6 @@ kata1.spec.ts:1:42 - error TS2307: Cannot find module './kata1'.
     at Function.Module._load (internal/modules/cjs/loader.js:620:12)
     at Module.require (internal/modules/cjs/loader.js:723:19)
 npm ERR! Test failed.  See above for more details.
-
    #+END_SRC
 
    Although that's an error, right now it means success. You got as

--- a/kata1.spec.ts
+++ b/kata1.spec.ts
@@ -1,128 +1,74 @@
-import { BaseParser, ParsingError } from "./kata1";
+import { BaseParser, ParsingError } from "./api";
 
-describe("#1 Kata - parsing: input and cursor", () => {
-  // The first Kata will teach you the basics about the flow of the
-  // parser through the input being parsed.
-  describe("Move the cursor forward on matching", () => {
-    it("should start with the cursor pointing to the position 0 in the input", () => {
-      const parser = new BaseParser();
-      expect(parser.cursor).toBe(0);
-    });
 
-    it("should provide accessor to the character of the input under cursor", () => {
-      // Given a new base parser
-      const parser = new BaseParser();
-      // When some input is set
-      parser.setInput("1234");
-      // Then there should be access to the character under the cursor
-      expect(parser.getCurrent()).toBe("1");
-    });
-
-    it("should move to the next character of the input under cursor", () => {
-      // Given a new base parser with some input
-      const parser = new BaseParser();
-      parser.setInput("abcd");
-      // When the cursor is moved one character
-      parser.next();
-      // Then it should point at the second character of the input string
-      expect(parser.getCurrent()).toBe("b");
-    });
-
-    it("should error if next goes beyound the size of input", () => {
-      // Given a new parser with some input
-      const parser = new BaseParser();
-      parser.setInput("");
-      // When cursor overflows the size of input
-      // Then it should error
-      expect(() => parser.next())
-        .toThrow(new ParsingError('End of input'));
-    });
-
-    it("should expect successfuly that a character is at the cursor", () => {
-      // Given a base parser with some input and a cursor
-      const parser = new BaseParser();
-      parser.setInput("1234");
-      expect(parser.cursor).toBe(0);
-      // When an expected character is under the cursor
-      expect(parser.expect("1")).toBe("1");
-      // Then it should move the cursor forward
-      expect(parser.cursor).toBe(1);
-      expect(parser.getCurrent()).toBe("2");
-    });
-
-    it("should raise an error if expected character is not under the cursor", () => {
-      // Given a base parser with some input and a cursor
-      const parser = new BaseParser();
-      parser.setInput("1234");
-      expect(parser.cursor).toBe(0);
-      // When an expected character is NOT under the cursor
-      // Then it should throw an error
-      expect(() => parser.expect("2"))
-        .toThrow(new ParsingError("Expected '2', got '1'"));
-    });
-
-    it("should provide a lil helper to expect an entire string", () => {
-      // Given a base parser with some input and a cursor
-      const parser = new BaseParser();
-      parser.setInput("sweeeet");
-      // When a string is expected
-      const output = parser.expectString("sweeee");
-      // Then it will return the expected string
-      expect(output).toBe("sweeee");
-      // And then it will move the cursor to right after the string just consumed
-      expect(parser.cursor).toBe(6);
-      expect(parser.getCurrent()).toBe("t");
-    });
+describe("#1 Kata - Move the cursor forward on matching", () => {
+  it("should start with the cursor pointing to the position 0 in the input", () => {
+    const parser = new BaseParser();
+    expect(parser.cursor).toBe(0);
   });
 
-  describe("Matching Expressions", () => {
-    describe("zeroOrMore", () => {
-      it("should capture as much of the input as possible", () => {
-        // Given a base parser with some input
-        const parser = new BaseParser();
-        parser.setInput("1234abcd");
-        // And given a function that
-        const integers = () => {
-          // Check if the current char is a digit and move
-          // the cursor forward if so and move on
-          const current = parser.getCurrent();
-          if (/\d/.test(current)) {
-            parser.next();
-            return current;
-          }
-          // Stop the loop at 
-          parser.error('Not Int');
-        };
-        // When a function that will 
-        const output = parser.zeroOrMore(integers);
-        // Then it should consume all the input since it matches
-        expect(output).toEqual(['1', '2', '3', '4']);
-      });
-    });
+  it("should provide accessor to the character of the input under cursor", () => {
+    // Given a new base parser
+    const parser = new BaseParser();
+    // When some input is set
+    parser.setInput("1234");
+    // Then there should be access to the character under the cursor
+    expect(parser.getCurrent()).toBe("1");
+  });
 
-    describe("or", () => {
-      it("should choose the first expression that succeeds", () => {
-        // Given a new base parser with some input
-        const parser = new BaseParser();
-        parser.setInput("abacate");
-        // When faced with a list of options, where just the last one
-        // matches successfuly
-        const output = parser.or([
-          () => parser.expectString("abelha"),
-          () => parser.expectString("abada"),
-          () => parser.expectString("abacate"),
-        ]);
-        // Then it should match the successful one
-        expect(output).toBe("abacate");
-      });
-      it("should fail if no option succeeds", () => {
-        // Given a new base parser with some input
-        const parser = new BaseParser();
-        parser.setInput("abacate");
-        // When faced with a list of options
-        expect(() => parser.or([() => parser.error("a"), () => parser.error("b")]))
-          .toThrow(new ParsingError('No option found'));
-      });
-    });
+  it("should move to the next character of the input under cursor", () => {
+    // Given a new base parser with some input
+    const parser = new BaseParser();
+    parser.setInput("abcd");
+    // When the cursor is moved one character
+    parser.next();
+    // Then it should point at the second character of the input string
+    expect(parser.getCurrent()).toBe("b");
+  });
+
+  it("should error if next goes beyound the size of input", () => {
+    // Given a new parser with some input
+    const parser = new BaseParser();
+    parser.setInput("");
+    // When cursor overflows the size of input
+    // Then it should error
+    expect(() => parser.next())
+      .toThrow(new ParsingError('End of input'));
+  });
+
+  it("should expect successfuly that a character is at the cursor", () => {
+    // Given a base parser with some input and a cursor
+    const parser = new BaseParser();
+    parser.setInput("1234");
+    expect(parser.cursor).toBe(0);
+    // When an expected character is under the cursor
+    expect(parser.expect("1")).toBe("1");
+    // Then it should move the cursor forward
+    expect(parser.cursor).toBe(1);
+    expect(parser.getCurrent()).toBe("2");
+  });
+
+  it("should raise an error if expected character is not under the cursor", () => {
+    // Given a base parser with some input and a cursor
+    const parser = new BaseParser();
+    parser.setInput("1234");
+    expect(parser.cursor).toBe(0);
+    // When an expected character is NOT under the cursor
+    // Then it should throw an error
+    expect(() => parser.expect("2"))
+      .toThrow(new ParsingError("Expected '2', got '1'"));
+  });
+
+  it("should provide a lil helper to expect an entire string", () => {
+    // Given a base parser with some input and a cursor
+    const parser = new BaseParser();
+    parser.setInput("sweeeet");
+    // When a string is expected
+    const output = parser.expectString("sweeee");
+    // Then it will return the expected string
+    expect(output).toBe("sweeee");
+    // And then it will move the cursor to right after the string just consumed
+    expect(parser.cursor).toBe(6);
+    expect(parser.getCurrent()).toBe("t");
   });
 });

--- a/kata2.spec.ts
+++ b/kata2.spec.ts
@@ -1,78 +1,67 @@
-import { ParsingError } from "./kata1";
-import { PrimitiveParser } from "./kata2";
+import { BaseParser, ParsingError } from "./api";
 
 
-describe("#2 Kata - Use Expressions to implement primitives", () => {
-  describe("Numbers", () => {
-    it("should parse a digit", () => {
-      // Given a parser with some input containing integers
-      const parser = new PrimitiveParser();
-      parser.setInput("1234");
-      // When the parser tries to consume a single digit
-      const output = parser.parseDigit();
-      // Then it should have consumed the first digit
-      expect(output).toBe("1");
-      expect(parser.getCurrent()).toBe("2");
-    });
-
-    it("should parse decimals", () => {
-      // Given a parser with some input containing integers
-      const parser = new PrimitiveParser();
-      parser.setInput("1234");
-      // When the parser tries to consume a decimal number with
-      // multiple digits
-      const output = parser.parseDecimal();
-      // Then it should have parsed the whole input
-      expect(output).toEqual(1234);
-    });
-
-    it("should parse hex-decimals", () => {
-      // Given a parser with some input containing a hex number
-      const parser = new PrimitiveParser();
-      parser.setInput("0xFF");
-      // When the parser tries to consume a decimal number with
-      // multiple digits
-      const output = parser.parseHexDecimal();
-      // Then it should have parsed the whole input
-      expect(output).toEqual(255);
-    });
-
-    it("should parse binary numbers", () => {
-      // Given a parser with some input containing a binary number
-      const parser = new PrimitiveParser();
-      parser.setInput("0b101010");
-      // When the parser tries to consume a decimal number with
-      // multiple digits
-      const output = parser.parseBinary();
-      // Then it should have parsed the whole input
-      expect(output).toEqual(42);
-    });
-
-    it("should parse floating point numbers", () => {
-      // Given a parser with some input containing a float number
-      const parser = new PrimitiveParser();
-      parser.setInput("0.55");
-      // When the parser tries to consume a decimal number with
-      // multiple digits
-      const output = parser.parseFloat();
-      // Then it should have parsed the whole input
-      expect(output).toEqual(0.55);
-    });
-
-    it("should parse all supported number types", () => {
-      const parser = new PrimitiveParser();
-      // Decimals
-      parser.setInput("55");
-      expect(parser.parseNumber()).toBe(55);
-      // Hex decimals
-      parser.setInput("0xf");
-      expect(parser.parseNumber()).toBe(15);
-      // Binary numbers
-      parser.setInput("0b101010");
-      expect(parser.parseNumber()).toBe(42);
-      // Floats
-      parser.setInput("0.55");
-      expect(parser.parseNumber()).toBe(0.55);
+describe("#2 Kata - Matching Expressions", () => {
+  describe("zeroOrMore", () => {
+    it("should capture as much of the input as possible", () => {
+      // Given a base parser with some input
+      const parser = new BaseParser();
+      parser.setInput("1234abcd");
+      // And given a function that
+      const integers = () => {
+        // Check if the current char is a digit and move
+        // the cursor forward if so and move on
+        const current = parser.getCurrent();
+        if (/\d/.test(current)) {
+          parser.next();
+          return current;
+        }
+        // Stop the loop at the end of the sequence of integers
+        parser.error('Not Int');
+      };
+      // When zero or more integers are consumed
+      const output = parser.zeroOrMore(integers);
+      // Then it should consume all the input since it all matches
+      expect(output).toEqual(['1', '2', '3', '4']);
     });
   });
+
+  describe("or", () => {
+    it("should choose the first expression that succeeds", () => {
+      // Given a new base parser with some input
+      const parser = new BaseParser();
+      parser.setInput("abacate");
+      // When faced with a list of options, where just the last one
+      // matches successfuly
+      const output = parser.or([
+        () => parser.expectString("abelha"),
+        () => parser.expectString("abada"),
+        () => parser.expectString("abacate"),
+      ]);
+      // Then it should match the successful one
+      expect(output).toBe("abacate");
+    });
+
+    it("should fail if no option succeeds", () => {
+      // Given a new base parser with some input
+      const parser = new BaseParser();
+      parser.setInput("abacate");
+      // When faced with a list of options
+      expect(() => parser.or([() => parser.error("a"), () => parser.error("b")]))
+        .toThrow(new ParsingError('No option found'));
+    });
+  });
+
+  describe("oneOrMore", () => {
+  });
+
+  describe("optional", () => {
+  });
+
+  describe("not", () => {
+  });
+
+  describe("and", () => {
+  });
+
 });

--- a/kata3.spec.ts
+++ b/kata3.spec.ts
@@ -1,0 +1,77 @@
+import { ParsingError, PrimitiveParser } from "./api";
+
+
+describe("#3 Kata - Use Expressions to implement primitives", () => {
+  describe("Numbers", () => {
+    it("should parse a digit", () => {
+      // Given a parser with some input containing integers
+      const parser = new PrimitiveParser();
+      parser.setInput("1234");
+      // When the parser tries to consume a single digit
+      const output = parser.parseDigit();
+      // Then it should have consumed the first digit
+      expect(output).toBe("1");
+      expect(parser.getCurrent()).toBe("2");
+    });
+
+    it("should parse decimals", () => {
+      // Given a parser with some input containing integers
+      const parser = new PrimitiveParser();
+      parser.setInput("1234");
+      // When the parser tries to consume a decimal number with
+      // multiple digits
+      const output = parser.parseDecimal();
+      // Then it should have parsed the whole input
+      expect(output).toEqual(1234);
+    });
+
+    it("should parse hex-decimals", () => {
+      // Given a parser with some input containing a hex number
+      const parser = new PrimitiveParser();
+      parser.setInput("0xFF");
+      // When the parser tries to consume a decimal number with
+      // multiple digits
+      const output = parser.parseHexDecimal();
+      // Then it should have parsed the whole input
+      expect(output).toEqual(255);
+    });
+
+    it("should parse binary numbers", () => {
+      // Given a parser with some input containing a binary number
+      const parser = new PrimitiveParser();
+      parser.setInput("0b101010");
+      // When the parser tries to consume a decimal number with
+      // multiple digits
+      const output = parser.parseBinary();
+      // Then it should have parsed the whole input
+      expect(output).toEqual(42);
+    });
+
+    it("should parse floating point numbers", () => {
+      // Given a parser with some input containing a float number
+      const parser = new PrimitiveParser();
+      parser.setInput("0.55");
+      // When the parser tries to consume a decimal number with
+      // multiple digits
+      const output = parser.parseFloat();
+      // Then it should have parsed the whole input
+      expect(output).toEqual(0.55);
+    });
+
+    it("should parse all supported number types", () => {
+      const parser = new PrimitiveParser();
+      // Decimals
+      parser.setInput("55");
+      expect(parser.parseNumber()).toBe(55);
+      // Hex decimals
+      parser.setInput("0xf");
+      expect(parser.parseNumber()).toBe(15);
+      // Binary numbers
+      parser.setInput("0b101010");
+      expect(parser.parseNumber()).toBe(42);
+      // Floats
+      parser.setInput("0.55");
+      expect(parser.parseNumber()).toBe(0.55);
+    });
+  });
+});


### PR DESCRIPTION
This change moves the parsing expressions to kata2 and all the tests
for numbers to kata3. That's going to make the process a bit more
gradual.

Also, since the exercises can move from one kata to another, from now
one, all the tests will look for implementations only in a single
module called "api". You can save the following snippet within a file
called "api.ts" in your project if you were using the old structure
and don't want to change it for now:

  // api.ts
  export { BaseParser, ParsingError } from "./kata1";
  export { PrimitiveParser } from "./kata2";

And to confirm it still works, as always, run the command:

  $ npm test